### PR TITLE
Corrects the province population totals

### DIFF
--- a/sql/population.sql
+++ b/sql/population.sql
@@ -1722,19 +1722,20 @@ COPY public.population (geo_code, geo_level, sex, total) FROM stdin WITH DELIMIT
 NP,country,male,24400497
 NP,country,female,26261627
 7,province,male,1124864
-7,province,female,1124864
+7,province,female,1258383
 6,province,male,737483
-6,province,female,737483
+6,province,female,784244
 5,province,male,1917059
-5,province,female,1917059
+5,province,female,2147564
 4,province,male,1060103
-4,province,female,1060103
-3,province,male,2672594
-3,province,female,2670179
-2,province,male,2706078
-2,province,female,2705994
+4,province,female,1295533
+3,province,male,2509586
+3,province,female,2600631
+2,province,male,2694747
+2,province,female,2674024
 1,province,male,2069237
-1,province,female,2069237
+1,province,female,2290138
+
 \.
 
 


### PR DESCRIPTION
All the provinces had the same number for male and female: #43 

These new totals were derived from running a query on the database to
sum up the district totals for each province:
```sql
select concat(pg.geo_code, ',province,', p.sex, ',', sum(p.total))
from wazimap_geography pg, wazimap_geography g, population p
where p.geo_level = 'district'
and p.geo_code = g.geo_code
and pg.geo_code = g.parent_code
and g.geo_level = 'district'
and pg.geo_level = 'province'
group by pg.geo_code, p.sex
order by pg.geo_code desc, p.sex desc;
```