### PR TITLE
Remove simpletables cat until we have simple tables

### DIFF
--- a/compose/web/bin/start-web
+++ b/compose/web/bin/start-web
@@ -15,9 +15,6 @@ export DATABASE_URL="postgresql://$POSTGRES_USERNAME:$POSTGRES_PASSWORD@$POSTGRE
 # setup pgpassfile for psql non-interactive authentication
 export PGPASSWORD="$POSTGRES_PASSWORD"
 
-# Setup Simpletable entries
-cat sql/simpletables/*.sql | psql -w -U "$POSTGRES_USERNAME"  -h "$POSTGRES_HOST"
-
 # Migrate
 python ./manage.py migrate --no-input
 


### PR DESCRIPTION
The line for getting data from the simpletables directory is causing the dockerized version to fail to start. This PR removes that line until we have "simple tables" to use.