### PR TITLE
Remove empty line at end of geo listings

### DIFF
--- a/sql/population.sql
+++ b/sql/population.sql
@@ -1763,7 +1763,6 @@ NP,country,female,26646283
 2,province,female,2674024
 1,province,male,2135803
 1,province,female,2364089
-
 \.
 
 


### PR DESCRIPTION
Empty line was causing failure to load data when copying it in from SQL file.