### PR TITLE
Specify hectares for unit of land measurement

### DIFF
--- a/wazimap_np/agriculture.py
+++ b/wazimap_np/agriculture.py
@@ -16,12 +16,12 @@ def get_agriculture_profile(geo_code, geo_level, session):
         area_has_data=True,
         land_distribution=land_dist,
         total_land={
-            'name': 'Total Land Use',
+            'name': 'Hectares',
             'values': {'this': total_land}
         },
         holding_distribution=holding_dist,
         total_holding={
-            'name': 'Total Land Holding Size',
+            'name': 'Hectares',
             'values': {'this': total_holding}
         }
     )

--- a/wazimap_np/templates/profile/sections/agriculture.html
+++ b/wazimap_np/templates/profile/sections/agriculture.html
@@ -14,7 +14,7 @@
                 <div class="column-two-thirds"
                      id="chart-histogram-agriculture-land_distribution"
                      data-stat-type="scaled-percentage"
-                     data-chart-title="Agriculture Land Use Area"></div>
+                     data-chart-title="Agriculture land use area"></div>
                 <small>Source: <br>
                     <a href="http://nationaldata.gov.np/">National Data Profile</a>
                     <br>


### PR DESCRIPTION
This makes a small update to the agricultural and land use sections to specify hectares as the unit of measurement. It also sentence-cases one of the descriptions to match the style for the other sections.

![specify-hectares-for-land-unit](https://user-images.githubusercontent.com/3824492/63650947-df884080-c715-11e9-8ceb-c987804fbda0.png)
