### PR TITLE
Add source links for demographics

### DIFF
--- a/wazimap_np/templates/profile/sections/agriculture.html
+++ b/wazimap_np/templates/profile/sections/agriculture.html
@@ -16,7 +16,7 @@
                      data-stat-type="scaled-percentage"
                      data-chart-title="Agriculture Land Use Area"></div>
                 <small>Source: <br>
-                    <a href="http://nationaldata.gov.np/">National Data Profile</a>
+                    <a href="http://nationaldata.gov.np/" target="_blank">National Data Profile</a>
                     <br>
                 </small>
             </section>
@@ -33,7 +33,7 @@
                      data-stat-type="scaled-percentage"
                      data-chart-title="Agricultural holdings size by land tenure"></div>
                 <small>Source: <br>
-                    <a href="http://nationaldata.gov.np/">National Data Profile</a>
+                    <a href="http://nationaldata.gov.np/" target="_blank">National Data Profile</a>
                     <br>
                 </small>
             </section>

--- a/wazimap_np/templates/profile/sections/demographics.html
+++ b/wazimap_np/templates/profile/sections/demographics.html
@@ -12,6 +12,10 @@
                 </div>
                 <div class="column-three-quarters" id="chart-pie-demographics-pop_dist" data-stat-type="percentage"
                      data-chart-title="Sex"></div>
+                <small>Source: <br>
+                    <a href="http://nationaldata.gov.np/" target="_blank">National Data Profile</a>
+                    <br>
+                </small>
             </section>
 
             <section class="clearfix stat-row">
@@ -27,6 +31,10 @@
                          data-stat-type="scaled-percentage"
                          data-chart-title="Population by religion"></div>
                 </div>
+                <small>Source: <br>
+                    <a href="http://nationaldata.gov.np/" target="_blank">National Data Profile</a>
+                    <br>
+                </small>
             </section>
 
         </div>

--- a/wazimap_np/templates/profile/sections/households.html
+++ b/wazimap_np/templates/profile/sections/households.html
@@ -17,11 +17,12 @@
                 <div class="column-third">
                     {% include 'profile/_blocks/_stat_list.html' with stat=households.male_to_female_ratio decimals='true' %}
                 </div>
+            </section>
                 <small>Source: <br>
                     <a href="http://nationaldata.gov.np/" target="_blank">National Data Profile</a>
                     <br>
+                    <br>
                 </small>
-            </section>
             <section class="clearfix stat-row">
                 <h2><a class="permalink"
                        href="#household-construction-materials"


### PR DESCRIPTION
This updates the demographics section so that links to the source are displayed.

## Concerns

Perhaps we should consider having just one link somewhere, either at the top of the profile or in the "About" section so that we don't repeat the same link again and again. However, one advantage of having it directly in each section is that a user can go directly to the National Data Profile from wherever the user is browsing.

### With updated links

#### Demographics
![demographics-with-source-links](https://user-images.githubusercontent.com/3824492/63651291-bf0db580-c718-11e9-9265-b7aef3c486e1.png)


#### Households
![households-source-link-with-legend](https://user-images.githubusercontent.com/3824492/63651294-c46b0000-c718-11e9-8537-5fd0f1b9f62d.png)

### Before updated links

#### Demographics
![demographics-without-source-links](https://user-images.githubusercontent.com/3824492/63651299-d8aefd00-c718-11e9-9bdd-0c0bd83c004d.png)

#### Households
![households-source-link-without-legend](https://user-images.githubusercontent.com/3824492/63651297-d3ea4900-c718-11e9-9993-ca02285efcf5.png)
