### PR TITLE
Upgrade pip on container start

### DIFF
--- a/compose/web/Dockerfile
+++ b/compose/web/Dockerfile
@@ -15,6 +15,7 @@ RUN set -exu \
 WORKDIR /usr/src/app
 
 COPY requirements.txt /usr/src/app/requirements.txt
+RUN pip install --upgrade pip
 RUN pip install --no-cache-dir --global-option=build_ext --global-option="-I/usr/include/gdal/" -r requirements.txt
 
 COPY . /usr/src/app/


### PR DESCRIPTION
When starting the web container, there is a warning that pip is out of date and should be updated. This updates the container start to upgrade pip when it is being built.