### PR TITLE
Upgrade to ACME v. 2 for Let's Encrypt

### DIFF
--- a/compose/caddy/Dockerfile
+++ b/compose/caddy/Dockerfile
@@ -1,3 +1,3 @@
-FROM abiosoft/caddy:0.10.6
+FROM abiosoft/caddy:0.10.12
 
 RUN apk add --no-cache bash

--- a/compose/caddy/bin/start-caddy
+++ b/compose/caddy/bin/start-caddy
@@ -5,8 +5,8 @@ set -eou pipefail
 : ${APP_ENV?"APP_ENV not set. Aborting !"}
 
 if [ "$APP_ENV" = "prod" ]; then
-    exec /usr/bin/caddy --conf /etc/Caddyfile --log stdout
+    exec /usr/bin/caddy --conf /etc/Caddyfile --log stdout -agree
 else
     # For stage etc. run the following, as it's not rate limited
-    exec /usr/bin/caddy -ca https://acme-staging.api.letsencrypt.org/directory --conf /etc/Caddyfile --log stdout
+    exec /usr/bin/caddy -ca https://acme-staging-v02.api.letsencrypt.org/directory --conf /etc/Caddyfile --log stdout -agree
 fi


### PR DESCRIPTION
ACME v. 1 is being phased out. This updates Caddy and Let's Encrypt settings for ACME v.2.

See https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430