### PR TITLE
Upgrade to Wazimap 1.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django==1.9.10
+Django==1.11.26
 django-cors-headers==2.4.1
 gunicorn==19.5.0
-wazimap[gdal]==1.1.1
+wazimap[gdal]==1.2.1
 GDAL==2.1.3
 Shapely==1.5.17
 whitenoise==3.3.1

--- a/wazimap_np/settings.py
+++ b/wazimap_np/settings.py
@@ -2,7 +2,7 @@
 from wazimap.settings import *  # noqa
 
 # install this app before Wazimap
-INSTALLED_APPS = ['wazimap_np'] + INSTALLED_APPS
+INSTALLED_APPS = ['wazimap_np', 'django.contrib.auth'] + INSTALLED_APPS
 
 DEBUG = False if (os.environ.get('APP_ENV', 'dev') == 'prod') else True
 


### PR DESCRIPTION
This is the next step in Wazimap library upgrades in preparation for upgrading to Python 3. This upgrade brings NepalMap Federal up to Wazimap 1.2.1 the latest published version of Wazimap for Python 2.7. This is to prepare for #84. 

## Screenshots

Here are some screenshots showing the project behaving correctly with Wazimap 1.2.1 and Django 1.11.26

Homepage
![homepage](https://user-images.githubusercontent.com/3824492/70381065-c80e4580-1909-11ea-888d-07a7151ce3c4.png)

National Profile
![national-profile](https://user-images.githubusercontent.com/3824492/70381060-c775af00-1909-11ea-8abe-b71ee389df51.png)

Province Profile
![province-1-profile](https://user-images.githubusercontent.com/3824492/70381080-0277e280-190a-11ea-99bb-01e0ea3c98a8.png)


District Profile
![top-of-taplejung-profile](https://user-images.githubusercontent.com/3824492/70381063-c80e4580-1909-11ea-8539-e184cb41c250.png)
![bottom-of-household-data-taplejung-district](https://user-images.githubusercontent.com/3824492/70381064-c80e4580-1909-11ea-83c2-4145e4e5c18b.png)
![makalu-local-profile](https://user-images.githubusercontent.com/3824492/70381061-c80e4580-1909-11ea-9e4f-c1d479e57470.png)

Map drill down for education level for a district
![drill-down-for-education-level-taplejung](https://user-images.githubusercontent.com/3824492/70381062-c80e4580-1909-11ea-84be-e156ca5cc9f9.png)
