### PR TITLE
Update Caddy to 0.11.5

### DIFF
--- a/compose/caddy/Dockerfile
+++ b/compose/caddy/Dockerfile
@@ -1,3 +1,3 @@
-FROM abiosoft/caddy:0.10.12
+FROM abiosoft/caddy:0.11.5
 
 RUN apk add --no-cache bash


### PR DESCRIPTION
This updates the Caddy image to 0.11.5

After the loss of the server at beta.nepalmap.org and a rebuild of the server, the previous caddy versioh 0.10.2, no longer correctly worked. Upgrading to 0.11.5 works.