### PR TITLE
Fixing National Parks generate an error #100 Issue 

### DIFF
--- a/wazimap_np/templatetags/nepal_format.py
+++ b/wazimap_np/templatetags/nepal_format.py
@@ -11,6 +11,10 @@ register = template.Library()
 
 @register.filter(name='nepal_format')
 def nepal_format(value):
+ 
+  if value == '':
+      return 0;
+
   d = decimal.Decimal(str(value))
   if d.as_tuple().exponent < -2:
     s = str(value)


### PR DESCRIPTION
@cliftonmcintosh @nikeshbalami 
Each numerical value in the site gets converted into Nepali format number system. However for some reason '0' values are considered as an empty string. Thus, the error was coming from the Nepal format .py file "decimal.InvalidOperation: Invalid literal for Decimal: ' ' "
The most simplest way I could think of to solve this issue was to catch the empty string values and return 0. I am still confused why it reads 0 as an empty string probably "SQL syntax."  
If this looks good, I can create another pull request for nepalmap.org site. 
Please let me know if there is anything missing. 