### PR TITLE
Upgrade to caddy v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ debug
 
 # Empty directories (for Compose mounts)
 static/*
-certs/*
+data/*
 
 # Keep files
 !.keep

--- a/compose.stage_prod.yml
+++ b/compose.stage_prod.yml
@@ -21,16 +21,15 @@ services:
       - ./compose/caddy/Caddyfile:/etc/Caddyfile
       - ./compose/common/bin/wait-for-it:/usr/local/sbin/wait-for-it
       - ./compose/caddy/bin/start-caddy:/usr/local/sbin/start-caddy
-      - ./certs:/etc/caddycerts
+      - ./data:/data
       - ./static:/static
     environment:
       - APP_ENV
       - TLS_EMAIL
       - HOST_NAME
-      - CADDYPATH=/etc/caddycerts
+      - STORAGE_ROOT=/data
       - PROXY_HOST=web
       - PROXY_PORT=8000
     ports:
         - "0.0.0.0:80:80"
         - "0.0.0.0:443:443"
-        # - "2015:2015" # Test Caddy without TLS `tls off` in Caddyfile and HOST_NAME=0.0.0.0

--- a/compose/caddy/Caddyfile
+++ b/compose/caddy/Caddyfile
@@ -1,13 +1,18 @@
-{$HOST_NAME}
-
-tls {$TLS_EMAIL}
-
-root /static
-
-proxy / {$PROXY_HOST}:{$PROXY_PORT} {
-    transparent
+{
+  acme_ca {$ACME_CA_URL}
+  email {$TLS_EMAIL}
+  admin off
+  storage file_system {
+    root {$STORAGE_ROOT}
+  }
 }
 
-log stdout
-errors stdout
-gzip
+{$HOST_NAME}
+
+root * /static
+
+reverse_proxy {$PROXY_HOST}:{$PROXY_PORT}
+
+encode gzip
+
+log

--- a/compose/caddy/Dockerfile
+++ b/compose/caddy/Dockerfile
@@ -1,3 +1,3 @@
-FROM abiosoft/caddy:0.10.6
+FROM caddy:2.0.0-alpine
 
 RUN apk add --no-cache bash

--- a/compose/caddy/bin/start-caddy
+++ b/compose/caddy/bin/start-caddy
@@ -4,9 +4,25 @@ set -eou pipefail
 
 : ${APP_ENV?"APP_ENV not set. Aborting !"}
 
-if [ "$APP_ENV" = "prod" ]; then
-    exec /usr/bin/caddy --conf /etc/Caddyfile --log stdout
-else
-    # For stage etc. run the following, as it's not rate limited
-    exec /usr/bin/caddy -ca https://acme-staging.api.letsencrypt.org/directory --conf /etc/Caddyfile --log stdout
-fi
+ACME_PROD_URL="https://acme-v02.api.letsencrypt.org/directory"
+ACME_STAGE_URL="https://acme-staging-v02.api.letsencrypt.org/directory"
+
+case "$APP_ENV" in
+  "stage")
+    export ACME_CA_URL="$ACME_STAGE_URL"
+    ;;
+  "prod")
+    export ACME_CA_URL="$ACME_PROD_URL"
+    ;;
+  *)
+    echo "APP_ENV not supported. Aborting !"
+    exit 1
+    ;;
+esac
+
+echo "Starting Caddy server"
+echo "Environment : $APP_ENV | HOST : $HOST_NAME"
+echo "Proxying to : $PROXY_HOST:$PROXY_PORT"
+echo "Acme CA URL :  $ACME_CA_URL"
+
+exec /usr/bin/caddy run --config /etc/Caddyfile

--- a/compose/common/bin/wait-for-it
+++ b/compose/common/bin/wait-for-it
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-#   Use this script to test if a given TCP host/port are available
-#   https://github.com/vishnubob/wait-for-it
+# https://github.com/vishnubob/wait-for-it/blob/ed77b63706ea721766a62ff22d3a251d8b4a6a30/wait-for-it.sh
+# Use this script to test if a given TCP host/port are available
 
-cmdname=$(basename $0)
+WAITFORIT_cmdname=${0##*/}
 
-echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
 
 usage()
 {
     cat << USAGE >&2
 Usage:
-    $cmdname host:port [-s] [-t timeout] [-- command args]
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
     -h HOST | --host=HOST       Host or IP under test
     -p PORT | --port=PORT       TCP port under test
                                 Alternatively, you specify the host and port as host:port
@@ -25,47 +25,47 @@ USAGE
 
 wait_for()
 {
-    if [[ $TIMEOUT -gt 0 ]]; then
-        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
     else
-        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
     fi
-    start_ts=$(date +%s)
+    WAITFORIT_start_ts=$(date +%s)
     while :
     do
-        if [[ $ISBUSY -eq 1 ]]; then
-            nc -z $HOST $PORT
-            result=$?
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
         else
-            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
-            result=$?
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
         fi
-        if [[ $result -eq 0 ]]; then
-            end_ts=$(date +%s)
-            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
             break
         fi
         sleep 1
     done
-    return $result
+    return $WAITFORIT_result
 }
 
 wait_for_wrapper()
 {
     # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
-    if [[ $QUIET -eq 1 ]]; then
-        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
     else
-        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
     fi
-    PID=$!
-    trap "kill -INT -$PID" INT
-    wait $PID
-    RESULT=$?
-    if [[ $RESULT -ne 0 ]]; then
-        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
     fi
-    return $RESULT
+    return $WAITFORIT_RESULT
 }
 
 # process arguments
@@ -73,53 +73,53 @@ while [[ $# -gt 0 ]]
 do
     case "$1" in
         *:* )
-        hostport=(${1//:/ })
-        HOST=${hostport[0]}
-        PORT=${hostport[1]}
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
         shift 1
         ;;
         --child)
-        CHILD=1
+        WAITFORIT_CHILD=1
         shift 1
         ;;
         -q | --quiet)
-        QUIET=1
+        WAITFORIT_QUIET=1
         shift 1
         ;;
         -s | --strict)
-        STRICT=1
+        WAITFORIT_STRICT=1
         shift 1
         ;;
         -h)
-        HOST="$2"
-        if [[ $HOST == "" ]]; then break; fi
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
         shift 2
         ;;
         --host=*)
-        HOST="${1#*=}"
+        WAITFORIT_HOST="${1#*=}"
         shift 1
         ;;
         -p)
-        PORT="$2"
-        if [[ $PORT == "" ]]; then break; fi
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
         shift 2
         ;;
         --port=*)
-        PORT="${1#*=}"
+        WAITFORIT_PORT="${1#*=}"
         shift 1
         ;;
         -t)
-        TIMEOUT="$2"
-        if [[ $TIMEOUT == "" ]]; then break; fi
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
         shift 2
         ;;
         --timeout=*)
-        TIMEOUT="${1#*=}"
+        WAITFORIT_TIMEOUT="${1#*=}"
         shift 1
         ;;
         --)
         shift
-        CLI=("$@")
+        WAITFORIT_CLI=("$@")
         break
         ;;
         --help)
@@ -132,47 +132,52 @@ do
     esac
 done
 
-if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
     echoerr "Error: you need to provide a host and port to test."
     usage
 fi
 
-TIMEOUT=${TIMEOUT:-15}
-STRICT=${STRICT:-0}
-CHILD=${CHILD:-0}
-QUIET=${QUIET:-0}
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
 
-# check to see if timeout is from busybox?
-# check to see if timeout is from busybox?
-TIMEOUT_PATH=$(realpath $(which timeout))
-if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
-        ISBUSY=1
-        BUSYTIMEFLAG="-t"
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
 else
-        ISBUSY=0
-        BUSYTIMEFLAG=""
+    WAITFORIT_ISBUSY=0
 fi
 
-if [[ $CHILD -gt 0 ]]; then
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
     wait_for
-    RESULT=$?
-    exit $RESULT
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
 else
-    if [[ $TIMEOUT -gt 0 ]]; then
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
         wait_for_wrapper
-        RESULT=$?
+        WAITFORIT_RESULT=$?
     else
         wait_for
-        RESULT=$?
+        WAITFORIT_RESULT=$?
     fi
 fi
 
-if [[ $CLI != "" ]]; then
-    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
-        echoerr "$cmdname: strict mode, refusing to execute subprocess"
-        exit $RESULT
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
     fi
-    exec "${CLI[@]}"
+    exec "${WAITFORIT_CLI[@]}"
 else
-    exit $RESULT
+    exit $WAITFORIT_RESULT
 fi

--- a/compose/web/Dockerfile
+++ b/compose/web/Dockerfile
@@ -1,30 +1,21 @@
 FROM library/python:2.7.14-stretch
 
 ENV PYTHONUNBUFFERED="true" \
-    PATH="/usr/src/app/compose/web/bin:/usr/src/app/compose/common/bin:${PATH}" \
-    GOSU_VERSION="1.10"
+    APP_SRC_PATH="/usr/src/app" \
+    PATH="/usr/src/app/compose/web/bin:/usr/src/app/compose/common/bin:${PATH}"
+
+WORKDIR $APP_SRC_PATH
 
 RUN set -exu \
-
-    # libgdal
     && apt-get update \
-    && apt-get install -y libgdal-dev=2.1.2+dfsg-5 postgresql-client \
+    && apt-get install -y libgdal-dev=2.1.2+dfsg-5 postgresql-client gosu \
     && rm -rf /var/lib/apt/lists/* \
+    && gosu nobody true
 
-    # gosu for easy step down from root
-    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu nobody true \
+COPY ./compose/web/requirements.txt $APP_SRC_PATH/requirements.txt
+RUN pip install --no-cache-dir --global-option=build_ext --global-option="-I/usr/include/gdal/" -r requirements.txt
 
-    # make workdir
-    && mkdir -p /usr/src/app
-
-WORKDIR /usr/src/app
-
-COPY compose/web/requirements.txt /usr/src/app/requirements.txt
-RUN pip install --no-cache-dir --global-option=build_ext --global-option="-I/usr/include/gdal/" -r requirements.txt 
-
-COPY . /usr/src/app/
+COPY . $APP_SRC_PATH
 
 ENTRYPOINT ["/usr/src/app/compose/web/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/compose/web/entrypoint.sh
+++ b/compose/web/entrypoint.sh
@@ -59,4 +59,4 @@ Starting as : uid($RUN_AS_UID)$RUN_AS_USER | gid($RUN_AS_GID)$RUN_AS_GROUP
 EOF
 
 # Switch to the user:group and exec
-exec /usr/local/bin/gosu "$RUN_AS_UID":"$RUN_AS_GID" "$@"
+exec gosu "$RUN_AS_UID":"$RUN_AS_GID" "$@"

--- a/compose/web/requirements.txt
+++ b/compose/web/requirements.txt
@@ -3,3 +3,7 @@ gunicorn==18.0
 wazimap[gdal]==0.7.3
 GDAL==2.1.3
 Shapely==1.5.17
+
+# Lock version to wazimap[gdal] minimum
+whitenoise==1.0.6
+django-cors-headers==1.1.0


### PR DESCRIPTION
Took the time to dig into docs for Caddy v2 and it was simple enough.

However, `master` seems to be broken for `make start` from scratch. Took me a while to lock certain versions and get it rolling further, but I still see a lot of warnings in the db import logs.

Also, since the dependencies used by this application is not very clear, I'd recommend using tool like `pip-compile` to create a full dependency list and freeze it in requirements.txt, esp. given most of the packages use are getting old and new ones get installed by default.

One more thing, I'm not sure of the migration path on keeping the same old certs, because options have changed in caddy on how/where it stores those files.

You should be able to `make start` on this branch, but I'm not sure what else could be broken.